### PR TITLE
chore(sdk): parse ActionGroups properly

### DIFF
--- a/state/memory/memory.go
+++ b/state/memory/memory.go
@@ -76,6 +76,10 @@ func (s *State) updateTask(item things.TaskActionItem) *things.Task {
 		ids := *item.P.AreaIDs
 		t.AreaIDs = ids
 	}
+	if item.P.ActionGroupIDs != nil {
+		ids := *item.P.ActionGroupIDs
+		t.ActionGroupIDs = ids
+	}
 	if item.P.ParentTaskIDs != nil {
 		ids := *item.P.ParentTaskIDs
 		t.ParentTaskIDs = ids

--- a/types.go
+++ b/types.go
@@ -161,6 +161,7 @@ type Task struct {
 	Index            int
 	AreaIDs          []string
 	ParentTaskIDs    []string
+	ActionGroupIDs   []string
 	InTrash          bool
 	Schedule         TaskSchedule
 	IsProject        bool
@@ -185,9 +186,9 @@ type TaskActionItemPayload struct {
 	InTrash           *bool         `json:"tr,omitempty"`
 	RecurrenceTaskIDs *[]string     `json:"rt,omitempty"`
 	Schedule          *TaskSchedule `json:"st,omitempty"`
+	ActionGroupIDs    *[]string     `json:"agr,omitempty"`
 	//  {
 	//      "acrd": null,
-	//      "agr": [],
 	//      "ar": [],
 	//      "ato": null,
 	//      "cd": 1495662927.014228,


### PR DESCRIPTION
ActionGroups are tasks, which can be identified by the `ACTIONGROUP-` UUID
prefix. Tasks can be referenced to actionGroups using the `agr` attribute