### PR TITLE
Improve README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,11 +1,10 @@
 # things cloud sdk
 
-[Things](https://culturedcode.com/things/) comes with a cloud based API, which can
-be used to synchronize data between devices.
-This is a golang SDK to interact with that API, opening the API so that you
-can enhance your Things experience on iOS and Mac.
+[Things] comes with a cloud based API, which can be used to synchronize data
+between devices. This is a golang SDK to interact with that API, opening the
+API so that you can enhance your Things experience on iOS and Mac.
 
-[![wercker status](https://app.wercker.com/status/ddec74f2f7406079026aa44e8a004a86/s/master "wercker status")](https://app.wercker.com/project/byKey/ddec74f2f7406079026aa44e8a004a86)
+[![wercker_status]][wercker_image]
 
 ## TODO
 
@@ -16,11 +15,11 @@ can enhance your Things experience on iOS and Mac.
   - [x] Account Deletion
 - [x] History management
   - [x] List Histories
-  - [x] Create History 
+  - [x] Create History
   - [x] Delete History
   - [x] Sync History
   - [ ] Item Management
-    - [x] read items 
+    - [x] read items
     - [x] write items
     - recurring tasks
       - [x] neverending
@@ -35,5 +34,10 @@ can enhance your Things experience on iOS and Mac.
 
 ## Note
 
-As there is no official API documentation available all requests need to be reverse engineered,
-which takes some time. Feel free to contribute and improve & extend this implementation.
+As there is no official API documentation available, all requests need to be
+reverse engineered, which takes some time. Feel free to contribute and improve
+& extend this implementation.
+
+[Things]: https://culturedcode.com/things/
+[wercker_image]: https://app.wercker.com/project/byKey/ddec74f2f7406079026aa44e8a004a86
+[wercker_status]: https://app.wercker.com/status/ddec74f2f7406079026aa44e8a004a86/s/master


### PR DESCRIPTION
I saw a few trailing spaces and took a closer look at the README.

- remove trailing spaces
- improve plain text paragraphs with reference style links
- improve plain text paragraphs with LF before 80th character

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/nicolai86/things-cloud-sdk/5)
<!-- Reviewable:end -->
